### PR TITLE
Fix compilation errors on Mac OSX

### DIFF
--- a/src/termios.cpp
+++ b/src/termios.cpp
@@ -28,6 +28,7 @@ static struct bauds {
 {57600, B57600},
 {115200, B115200},
 {230400, B230400},
+#ifndef __APPLE__
 {460800, B460800},
 {500000, B500000},
 {576000, B576000},
@@ -40,8 +41,13 @@ static struct bauds {
 {3000000, B3000000},
 {3500000, B3500000},
 {4000000, B4000000},
+#endif
 {-1, 0},
 };
+
+#ifndef CBAUD
+#define CBAUD 0000017
+#endif
 
 static int mask_to_baud(int mask) {
 	int i;


### PR DESCRIPTION
Based on [this issue](https://github.com/tomszilagyi/gen_serial/issues/1), some constants are not defined in Mac OS X.  This PR allows it to compile and run on OS X.

Note: I am less sure of my change with the "CBAUD" fix for OS X, but by all indications, I have initialized it to the correct constant.